### PR TITLE
fix: iOS crashes when opening multiple tooltips

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -12,6 +12,7 @@ import { HomeScreen } from "./src/home";
 import { LikeScreen } from "./src/like";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { ModalScreen } from "./src/modal";
+import { NormalScreen } from "./src/screen";
 
 StatusBar.setBarStyle("light-content");
 StatusBar.setHidden(true);
@@ -98,6 +99,13 @@ export default function App() {
           }}
         >
           <Stack.Screen name="modal" component={ModalScreen} />
+        </Stack.Group>
+        <Stack.Group
+          screenOptions={{
+            fullScreenGestureEnabled: true,
+          }}
+        >
+          <Stack.Screen name="normalScreen" component={NormalScreen} />
         </Stack.Group>
       </Stack.Navigator>
     </NavigationContainer>

--- a/example/src/home.tsx
+++ b/example/src/home.tsx
@@ -1,4 +1,11 @@
-import { Text, View, Image, ScrollView, Platform } from "react-native";
+import {
+  Text,
+  View,
+  Image,
+  ScrollView,
+  Platform,
+  Pressable,
+} from "react-native";
 
 import { CreateTooltip } from "./create-tooltip";
 

--- a/example/src/like.tsx
+++ b/example/src/like.tsx
@@ -12,7 +12,12 @@ export function LikeScreen() {
       >
         <Text className="">Open modal</Text>
       </Pressable>
-
+      <Pressable
+        onPress={() => navigation.navigate("normalScreen")}
+        className="items-center justify-center bg-gray-100 py-2 mb-10 px-4 rounded-lg"
+      >
+        <Text className="">Open a screen</Text>
+      </Pressable>
       <CreateTooltip text="Show" />
     </View>
   );

--- a/example/src/screen.tsx
+++ b/example/src/screen.tsx
@@ -1,0 +1,32 @@
+import { View, Text, Pressable } from "react-native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { useEffect, useState } from "react";
+import { CreateTooltip } from "./create-tooltip";
+// import * as Tooltip from "universal-tooltip";
+export function NormalScreen() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View className="flex-1 bg-gray-700 items-center pt-40 gap-10">
+      <Text className="font-bold text-white text-lg"></Text>
+      <CreateTooltip
+        title="tooltip"
+        text="A very long long long long long text tooltip"
+        side="top"
+        maxWidth={200}
+      />
+      <CreateTooltip
+        title="tooltip"
+        text="A very long long long long long text tooltip"
+        side="top"
+        maxWidth={200}
+      />
+      <CreateTooltip
+        title="tooltip"
+        text="A very long long long long long text tooltip"
+        side="top"
+        maxWidth={200}
+      />
+    </View>
+  );
+}

--- a/ios/UniversalTooltipView.swift
+++ b/ios/UniversalTooltipView.swift
@@ -70,10 +70,12 @@ class UniversalTooltipView: ExpoView {
     super.init(appContext: appContext)
   }
 
-
   override func didMoveToWindow() {
-    popover?.dismiss()
+    if self.window != nil {
+      popover?.dismiss()
+    }
   }
+  
   override func didUpdateReactSubviews() {
     let firstView = self.reactSubviews()[0] as! RCTView
     contentView = firstView


### PR DESCRIPTION
This PR is to fix iOS crashes when opening multiple tooltips and returning to the last screen. 

Before:  

https://github.com/alantoa/universal-tooltip/assets/37520667/ecb57b30-e533-4581-9a4e-772a7a42b891

After:
 
https://github.com/alantoa/universal-tooltip/assets/37520667/d64c0940-f31e-4c01-94c2-df56092cbb46

