### PR TITLE
Update build.gradle for AGP 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,13 +53,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   defaultConfig {


### PR DESCRIPTION
Hello @alantoa !

When migrating my apps to Expo SDK 50, I noticed this library doesn't have compatibility for AGP 8 & RN 0.73. This PR addresses that. Also see this conversation for more info: https://discord.com/channels/695411232856997968/1009056414028812299/1194550582107721859